### PR TITLE
Add functionality verify order sqlite

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+pyparsing = "*"
 
 [dev-packages]
 pycodestyle = "*"

--- a/examples/ordered_revenue.rdbu
+++ b/examples/ordered_revenue.rdbu
@@ -1,0 +1,18 @@
+BEGIN SETUP
+sales:
+month	revenue
+March	130
+April	50
+June    1000
+END
+
+BEGIN SELECT
+SELECT month FROM sales ORDER BY revenue DESC;
+END
+
+BEGIN ORDERED RESULT
+month
+June
+March
+April
+END


### PR DESCRIPTION
Hi professor Spinelli, it follows explanation for the work done for the open issue #3 . 

## What does this change
Added functionality for testing the order of the result for the databse ```sqlite```. 

## Execution and Expected Behaviour

**Step 1** [**File.rdbu**]: 

For activating the functionality for verifying the order,  create a file [dot] rdbu 
(e.g.) ordered_revenue.rdbu and in the last section related to **RESULT** 
 instead of the syntax ```BEGIN RESULT``` use ```BEGIN ORDERED RESULT```.
  
**Step 2** [**Terminal-Execute**]: 

if you run in the terminal: 
`python src/rdbunit/__main__.py --database=sqlite --results examples/ordered_revenue.rdbu | sqlite3`
then in the terminal will be displayed the following output: 
```
ok 1 - examples/ordered_revenue.rdbu: test_select_result
Result set:
1|June
2|March
3|April
1..1
```

If you modify either the query e.g. modify ORDER BY ... DESC -> ORDER BY ... ASC or the order of the result  in the block section `BEGIN ORDERED RESULT` then in the terminal will be displayed the following output:  

```
not ok 1 - examples/ordered_revenue.rdbu: test_select_result
Result set:
1|April
2|March
3|June
1..1
```
__Note__: An extra auto increment column id generated if you sellect the option [arg]  --results.
## Future Work / Direction 

This implementation supports the functionality for verifying the order for **sqlite**, simillarly and based on the syntax for the creation of the auto increment column , it would be implemented the functionality of order for the databases : PostgresSQL and MySQL (as they are the current supported). 

Note: The current code for the functionality of order  generates  exception  for the databases PostgresSQL and mySQL
(```BEGIN ORDERED RESULT not supported for DatabaseMySQL.```, </br>
```BEGIN ORDERED RESULT not supported for DatabasePostgreSQL```). 
